### PR TITLE
feat(test): Add tests for single-digit date and time values

### DIFF
--- a/test/brasil_datetime_test.dart
+++ b/test/brasil_datetime_test.dart
@@ -2,10 +2,12 @@ import 'package:brasil_datetime/brasil_datetime.dart';
 import 'package:test/test.dart';
 
 final data = DateTime(1987, 4, 22, 23, 37, 06);
+final data2 = DateTime(2024, 1, 5, 8, 9, 4);
 
 void main() {
-  test('dia, mês e ano', () => expect(data.diaMesAno(), '22/04/1987'));
-  test('dia', () => expect(data.dia(), '22'));
+  group('DateTime(1987, 4, 22, 23, 37, 06)', () {
+    test('dia, mês e ano', () => expect(data.diaMesAno(), '22/04/1987'));
+    test('dia', () => expect(data.dia(), '22'));
   test('dia da semana', () => expect(data.diaSemana(), 'quarta-feira'));
   test('dia da semana abreviado', () => expect(data.diaSemanaAbrev(), 'qua.'));
   test('mês', () => expect(data.mes(), 'abril'));
@@ -63,4 +65,67 @@ void main() {
   test('minuto e segundo', () => expect(data.minutoSegundo(), '37:06'));
   test('dia, mes, ano, hora e minuto',
       () => expect(data.diaMesAnoHoraMinuto(), '22/04/1987 23:37'));
+  });
+
+  group('DateTime(2024, 1, 5, 8, 9, 4)', () {
+    test('dia, mês e ano', () => expect(data2.diaMesAno(), '05/01/2024'));
+    test('dia', () => expect(data2.dia(), '5'));
+    test('dia da semana', () => expect(data2.diaSemana(), 'sexta-feira'));
+    test('dia da semana abreviado', () => expect(data2.diaSemanaAbrev(), 'sex.'));
+    test('mês', () => expect(data2.mes(), 'janeiro'));
+    test('mês abreviado', () => expect(data2.mesAbrev(), 'jan.'));
+    test('mês no ano', () => expect(data2.mesNoAno(), '1'));
+    test('dia e mês', () => expect(data2.diaMes(), '05/01'));
+    test('dia e mês abreviado', () => expect(data2.diaMesAbrev(), '5 de jan.'));
+    test('dia da semana e mês abreviado',
+        () => expect(data2.diaSemanaMesAbrev(), 'sex., 5 de jan.'));
+    test(
+        'dia da semana e mês', () => expect(data2.diaSemanaEMes(), 'sex., 05/01'));
+    test('dia e mês', () => expect(data2.diaMesExt(), '5 de janeiro'));
+    test('mês (MMMM)',
+        () => expect(data2.diaSemanaMesExt(), 'sexta-feira, 5 de janeiro'));
+
+    test('trimestre abreviado', () => expect(data2.trimestreAbrev(), 'T1'));
+    test('trimestre', () => expect(data2.trimestre(), '1º trimestre'));
+    test('ano', () => expect(data2.ano(), '2024'));
+    test('ano e mês', () => expect(data2.anoMes(), '01/2024'));
+    test('semana, dia, mês e ano abreviado',
+        () => expect(data2.semanaDiaMesAnoAbrev(), 'sex., 05/01/2024'));
+    test('mês e ano abreviado', () => expect(data2.mesAnoAbrev(), 'jan. de 2024'));
+
+    test('dia, mês e ano abreviado',
+        () => expect(data2.diaMesAnoAbrev(), '5 de jan. de 2024'));
+
+    test('semana, dia, mês e ano por extenso abreviado',
+        () => expect(data2.semanaDiaMesAnoExtAbrev(), 'sex., 5 de jan. de 2024'));
+
+    test(
+        'mês e ano por extenso', () => expect(data2.mesAnoExt(), 'janeiro de 2024'));
+
+    test('dia, mês e ano por extenso',
+        () => expect(data2.diaMesAnoExt(), '5 de janeiro de 2024'));
+
+    test(
+        'semana, dia, mês e ano por extenso',
+        () => expect(
+            data2.semanaDiaMesAnoExt(), 'sexta-feira, 5 de janeiro de 2024'));
+
+    test('trimestre e ano abreviado',
+        () => expect(data2.trimestreAnoAbrev(), 'T1 de 2024'));
+
+    test('trimestre a no por extenso',
+        () => expect(data2.trimestreAnoExt(), '1º trimestre de 2024'));
+
+    test('hora', () => expect(data2.hora(), '08'));
+
+    test('hora e minuto', () => expect(data2.horaMinuto(), '08:09'));
+
+    test('hora, minuto e segundo',
+        () => expect(data2.horaMinutoSegundo(), '08:09:04'));
+    test('minuto', () => expect(data2.minuto(), '9'));
+    test('segundo', () => expect(data2.segundo(), '4'));
+    test('minuto e segundo', () => expect(data2.minutoSegundo(), '09:04'));
+    test('dia, mes, ano, hora e minuto',
+        () => expect(data2.diaMesAnoHoraMinuto(), '05/01/2024 08:09'));
+  });
 }


### PR DESCRIPTION
This commit enhances the test suite by adding a new set of tests that cover `DateTime` instances with single-digit values for day, month, hour, minute, and second.

A new `DateTime` object, `DateTime(2024, 1, 5, 8, 9, 4)`, was introduced to validate the formatting logic for these specific edge cases, ensuring that padding and formatting are handled correctly.

The new tests are organized within a separate `group` in `test/brasil_datetime_test.dart` to maintain clarity and structure. All existing and new tests pass, confirming that no regressions have been introduced.